### PR TITLE
📝 Reword intro and fix challenge 2 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To be able to:
 
 ## Morning Challenge
 
-Callbacks are awesome as they allow us to work with asynchronous code by waiting until a response comes back before we do something with it. However, this waiting can begin to make our code look messy when we need to link multiple async functions together. This is when **promises** can become super useful, they're a wrapper around callbacks . Below is an example of linking 5 async functions with error first callbacks compared to promises.
+Callbacks are awesome as they allow us to write asynchronous functions that wait until a response comes back before we do something with it (without blocking the rest of our code). However, our code can look messy when we need to link multiple async functions together. This is when **promises** are super useful, they're a wrapper for async callbacks. Let's have a look at how they can make our code easier to read. Below we compare 5 async functions implemented with error first callbacks and promises.
 
 ### Calling Error First Callbacks
 ```js
@@ -67,7 +67,7 @@ readAFile((err, res) => {
 
 ### Promises
 ```js
-const readAFile = (url) => {
+const readAFile = () => {
   // here you create a new Promise
   return new Promise((resolve, reject) => {
     //here you do something async
@@ -81,23 +81,30 @@ const readAFile = (url) => {
 }
 
 //now lets call it
-readAFile.then((res)=> console.log(res)).catch((err)=> console.log(err))
+readAFile
+  .then((res)=> console.log(res))
+  .catch((err)=> console.log(err))
 ```
+## Write a Promise
+Read [MDN's docs on Promises]( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Creating_a_Promise) to see how they are written.
 
 ## Challenge One
 In `challenge.js` you will find code to make an api call using the http module. Your challenge is to refactor this code into a new Promise.
 
-_Remember to use the docs provided at the top_
+Call your function from your terminal by typing:
+```bash
+node challenge.js
+```
 
 ## Challenge Two
 Nice work on your Promise! Now let's have a go at linking Promises. Your challenge is to:
-1. make an api call to the pokeApi to find out about pikachu
-2. make a second Promise that grabs pikachu's first move and find out more information about it's first `held_item`
-3. Link the two Promises together so that the second starts when the first is fulfilled.
+1. make an api call to the pokeApi to find out about Pikachu.
+2. write a function that returns a Promise to grab information about Pikachu's first `held_item`.
+3. link the two Promises together so that the second is called when the first is fulfilled.
 
 ## Challenge Three
 Did you really finish that fast :dash: ? Okay, so now your challenge is to find out info on the 3 starter pokemon (Bulbasaur :leaves:, Charmander :fire: & Squirtle :sweat_drops: ) and print the return info. To do this you need to:
-- Send off the 3 api calls one after the other
+- Send off the 3 api calls at once
 - Only print when all thee have fulfilled.
 
 [These docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) will be your friend :heart:

--- a/challenge.js
+++ b/challenge.js
@@ -1,7 +1,7 @@
 const https = require('https')
 
-const pokeUrl = pokemon => `https://pokeapi.co/api/v2/pokemon/${pokemon}/`
-const pikaUrl = pokeUrl('pikachu')
+const makePokeUrl = pokemon => `https://pokeapi.co/api/v2/pokemon/${pokemon}/`
+const pikaUrl = makePokeUrl('pikachu')
 
 const myApiCall = (url, callback) => {
   https
@@ -14,7 +14,7 @@ const myApiCall = (url, callback) => {
         try {
           callback(null, JSON.parse(data))
         } catch (e) {
-          callback('It dun broked')
+          callback('Oops, this isn\'t JSON')
         }
       })
     })

--- a/solution.js
+++ b/solution.js
@@ -1,7 +1,8 @@
 const https = require('https')
 
-const pokeUrl = pokemon => `https://pokeapi.co/api/v2/pokemon/${pokemon}/`
-const pikaUrl = pokeUrl('pikachu')
+const makePokeUrl = pokemon => `https://pokeapi.co/api/v2/pokemon/${pokemon}/`
+const pikaUrl = makePokeUrl('pikachu')
+
 // challenge 1
 const myPromiseApi = url => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Fixes #9
Supersedes #13 

- reworded the intro to be more informative
- removed rogue param in example
- made it more explicit they should read the docs themselves
- updated try/catch err response for `JSON.parse` to be more explicit why it's there
- fixes typo in challenge 2
- rename url function 
- add run instructions to challenge 1